### PR TITLE
Add WP-CLI environment variables

### DIFF
--- a/wpdistillery/wpdistillery.sh
+++ b/wpdistillery/wpdistillery.sh
@@ -20,6 +20,9 @@ function continue_error {
 }
 trap 'continue_error' ERR
 
+# WP-CLI environment variable
+export WP_CLI_CACHE_DIR=/home/vagrant/.wp-cli/cache
+
 # REQUIREMENTS
 ####################################################################################################
 


### PR DESCRIPTION
Fixes issue #66 wp-cli mkdir() Permission denied